### PR TITLE
feat: Middleware support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Handler, Router } from 'express';
 import { existsSync, lstatSync, readdirSync } from 'fs';
 import { dirname, join, resolve } from 'path';
+import { parseMiddleware } from './middleware';
 
 export type Method = 'get'|'post'|'put'|'patch'|'delete'|'all';
 const METHODS = Object.freeze<Method>(['get', 'post', 'put', 'patch', 'delete', 'all']);
@@ -20,11 +21,18 @@ const createRouteLoader = (basedir: string, router: Router, strict: boolean) => 
     const route = join(routepath, routename);
     const handlers = Object.entries<Handler>(require(filepath));
 
+    // find any middlewares first before looping through each handler
+    const middlewares = parseMiddleware(handlers);
+
     for (const [method, handler] of handlers) {
       if (strict && !METHODS.includes(method as Method)) {
         throw new Error(`Extraneous exports detected at ${filepath}`);
       }
-      router[method]?.(route, handler);
+
+      if (router[method]) {
+        const middleware = middlewares.getMiddleware(method as Method);
+        router[method](route, ...middleware, handler);
+      }
     }
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,9 @@ import { Handler, Router } from 'express';
 import { existsSync, lstatSync, readdirSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { parseMiddleware } from './middleware';
+import { Method, RouterOpts } from './types';
 
-export type Method = 'get'|'post'|'put'|'patch'|'delete'|'all';
 const METHODS = Object.freeze<Method>(['get', 'post', 'put', 'patch', 'delete', 'all']);
-
-export interface RouterOpts {
-  baseDir?: string;
-  strictExports?: boolean;
-}
-
 const isDirectory = (path: string) => lstatSync(path).isDirectory();
 
 const createRouteLoader = (basedir: string, router: Router, strict: boolean) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,6 @@
 import { Handler } from 'express';
-import { Method } from '.';
+import { Method, Middlewares } from 'types';
 
-export type Middlewares = Handler|Handler[]|Partial<Record<Method, Handler|Handler[]>>;
 type Handlers = [string, Handler|Handler[]][];
 
 const getMiddlewareFromList = (handlers: Handlers): Middlewares => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,38 @@
+import { Handler } from 'express';
+import { Method } from '.';
+
+export type Middlewares = Handler|Handler[]|Partial<Record<Method, Handler|Handler[]>>;
+type Handlers = [string, Handler|Handler[]][];
+
+const getMiddlewareFromList = (handlers: Handlers): Middlewares => {
+  for (let i = 0, n = handlers.length; i < n; i++) {
+    const [method, middleware] = handlers[i];
+    if (method !== 'middlewares') continue;
+
+    handlers.splice(i, 1); // pop middleware off from entries
+    return middleware;
+  }
+};
+
+export const parseMiddleware = (handlers: Handlers) => {
+  const middlewares = getMiddlewareFromList(handlers);
+
+  // always return an array of handlers for spread syntax.
+  // if middleware is an record with http methods:
+  // grab the matching method and return as an array
+  const getMiddleware = (method: Method): Handler[] => {
+    if (!middlewares) return [];
+
+    if (Array.isArray(middlewares)) return middlewares;
+    if (typeof middlewares === 'function') return [middlewares];
+
+    const methodMiddleware = middlewares[method];
+    if (methodMiddleware) {
+      return Array.isArray(methodMiddleware) ? methodMiddleware : [methodMiddleware];
+    }
+
+    return [];
+  };
+
+  return { getMiddleware };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+import { Handler } from 'express';
+
+export type Method = 'get'|'post'|'put'|'patch'|'delete'|'all';
+
+export interface RouterOpts {
+  baseDir?: string;
+  strictExports?: boolean;
+}
+
+export type Middlewares = Handler|Handler[]|Partial<Record<Method, Handler|Handler[]>>;


### PR DESCRIPTION
Addresses #1. Adds support for middlewares in a per-file/per-handler basis.

Picks up middlewares using an exported variable `middlewares`.
```ts
import { Middlewares } from 'fs-express-router';
export const middlewares: Middlewares;
```