### PR TITLE
fix: "delete" export name conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ and builds the route based on the file's path and applies the exported verb (`ex
 
 ### Sample Handlers
 
+**Important**: `delete` method is aliased as `del`, since `delete` is a reserved keyword.
+
 ```ts
 // src/routes/index.ts
 // GET /
@@ -60,6 +62,11 @@ interface Params {
 // GET /users/:id
 export const get: RequestHandler<Params> = (req, res) => {
   res.json({ userId: req.params.id });
+}
+
+// DELETE /users/:id
+export const del: RequestHandler<Params> = (req, res) => {
+  res.json({ userId: req.params.id, deleted: 1 });
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const routerOpts: RouterOpts = {
   baseDir: join(__dirname, 'routes'), // point to your routes directory
 };
 
-const router = createRouter();
+const router = createRouter(routerOpts);
 app.use('/', router);
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and builds the route based on the file's path and applies the exported verb (`ex
 ```md
 ├── routes/
 │   ├── users/
-│   │   └── :id(\d+)/
+│   │   └── :id/
 │   │       ├── index.ts
 │   │       └── data.ts
 │   └── index.ts
@@ -52,29 +52,29 @@ export const get: RequestHandler = (req, res) => {
 ```
 
 ```ts
-// src/routes/users/:id(\d+)/index.ts
+// src/routes/users/:id/index.ts
 interface Params {
   id: string;
 }
 
-// GET /users/:id(\d+)
+// GET /users/:id
 export const get: RequestHandler<Params> = (req, res) => {
   res.json({ userId: req.params.id });
 }
 ```
 
 ```ts
-// src/routes/users/:id(\d+)/data.ts
+// src/routes/users/:id/data.ts
 interface Params {
   id: string;
 }
 
-// GET /users/:id(\d+)/data
+// GET /users/:id/data
 export const get: RequestHandler<Params> = (req, res) => {
   res.json({ userId: req.params.id, name: 'foo' });
 }
 
-// POST /users/:id(\d+)/data
+// POST /users/:id/data
 export const post: RequestHandler<Params> = (req, res) => {
   res.json({ userId: req.params.id, ok: 1 });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "fs-express-router",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.4",
+      "version": "2.0.0",
       "license": "GPL-2.0",
       "dependencies": {
         "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-express-router",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "Simple File System Routing inspired by NuxtJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/route-loader.ts
+++ b/src/route-loader.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'path';
 import { parseMiddleware } from './middleware';
 import { Method } from './types';
 
-const METHODS = Object.freeze<Method>(['get', 'post', 'put', 'patch', 'delete', 'all']);
+const METHODS = Object.freeze<Method>(['get', 'post', 'put', 'patch', 'del', 'all']);
 
 export const createRouteLoader = (basedir: string, router: Router, strict: boolean) => {
   return (filename: string, filepath: string) => {
@@ -21,9 +21,11 @@ export const createRouteLoader = (basedir: string, router: Router, strict: boole
         throw new Error(`Extraneous exports detected at ${filepath}`);
       }
 
-      if (router[method]) {
+      const verb = method === 'del' ? 'delete' : method;
+
+      if (router[verb]) {
         const middleware = middlewares.getMiddleware(method as Method);
-        router[method](route, ...middleware, handler);
+        router[verb](route, ...middleware, handler);
       }
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Handler } from 'express';
 
-export type Method = 'get'|'post'|'put'|'patch'|'delete'|'all';
+export type Method = 'get'|'post'|'put'|'patch'|'del'|'all';
 
 export interface RouterOpts {
   baseDir?: string;


### PR DESCRIPTION
Fixes #3. Aliases `delete` as `del`.

```ts
export const middlewares: Middlewares = {
  async del(req, res, next) { }
};

export const del: RequestHandler;
```