### PR TITLE
fix: Windows routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and builds the route based on the file's path and applies the exported verb (`ex
 ```md
 ├── routes/
 │   ├── users/
-│   │   └── :id/
+│   │   └── _id/
 │   │       ├── index.ts
 │   │       └── data.ts
 │   └── index.ts
@@ -54,7 +54,7 @@ export const get: RequestHandler = (req, res) => {
 ```
 
 ```ts
-// src/routes/users/:id/index.ts
+// src/routes/users/_id/index.ts
 interface Params {
   id: string;
 }
@@ -71,7 +71,7 @@ export const del: RequestHandler<Params> = (req, res) => {
 ```
 
 ```ts
-// src/routes/users/:id/data.ts
+// src/routes/users/_id/data.ts
 interface Params {
   id: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "fs-express-router",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "GPL-2.0",
       "dependencies": {
         "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-express-router",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Simple File System Routing inspired by NuxtJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/route-loader.ts
+++ b/src/route-loader.ts
@@ -9,12 +9,12 @@ const normalizePath: (path: string) => string = sep === win32.sep
   ? path => path.replace(/\\/g, posix.sep)
   : path => path;
 
-export const createRouteLoader = (basedir: string, router: Router, strict: boolean) => {
+export const createRouteLoader = (rootdir: string, router: Router, strict: boolean) => {
   return (filename: string, filepath: string) => {
-    const routepath = dirname(filepath.slice(basedir.length)); // trim extra directories from route
-    const routename = filename.startsWith('index') ? '' : filename.replace(/\..*$/, ''); // parse proper filename
+    const basedir = dirname(filepath.slice(rootdir.length)); // remove root directory from file path
+    const file = filename.startsWith('index') ? '' : filename.replace(/\..*$/, '');
 
-    const route = normalizePath(join(routepath, routename));
+    const route = normalizePath(join(basedir, file));
     const handlers = Object.entries<Handler>(require(filepath));
 
     // find any middlewares first before looping through each handler

--- a/src/route-loader.ts
+++ b/src/route-loader.ts
@@ -1,16 +1,20 @@
 import { Handler, Router } from 'express';
-import { dirname, join } from 'path';
+import { dirname, join, posix, sep, win32 } from 'path';
 import { parseMiddleware } from './middleware';
 import { Method } from './types';
 
 const METHODS = Object.freeze<Method>(['get', 'post', 'put', 'patch', 'del', 'all']);
+
+const normalizePath: (path: string) => string = sep === win32.sep
+  ? path => path.replace(/\\/g, posix.sep)
+  : path => path;
 
 export const createRouteLoader = (basedir: string, router: Router, strict: boolean) => {
   return (filename: string, filepath: string) => {
     const routepath = dirname(filepath.slice(basedir.length)); // trim extra directories from route
     const routename = filename.startsWith('index') ? '' : filename.replace(/\..*$/, ''); // parse proper filename
 
-    const route = join(routepath, routename);
+    const route = normalizePath(join(routepath, routename));
     const handlers = Object.entries<Handler>(require(filepath));
 
     // find any middlewares first before looping through each handler

--- a/src/route-loader.ts
+++ b/src/route-loader.ts
@@ -9,12 +9,19 @@ const normalizePath: (path: string) => string = sep === win32.sep
   ? path => path.replace(/\\/g, posix.sep)
   : path => path;
 
+const normalizeRoute = (route: string) => route.replace(/_/g, ':');
+
+const parseRoute = (basedir: string, file: string) => {
+  const route = normalizePath(join(basedir, file));
+  return normalizeRoute(route);
+};
+
 export const createRouteLoader = (rootdir: string, router: Router, strict: boolean) => {
   return (filename: string, filepath: string) => {
     const basedir = dirname(filepath.slice(rootdir.length)); // remove root directory from file path
     const file = filename.startsWith('index') ? '' : filename.replace(/\..*$/, '');
 
-    const route = normalizePath(join(basedir, file));
+    const route = parseRoute(basedir, file);
     const handlers = Object.entries<Handler>(require(filepath));
 
     // find any middlewares first before looping through each handler


### PR DESCRIPTION
Replaces Windows' `\` separator with Posix `/` separator.
Aliases `_` in paths for `:` in routes.

Fixes #5.